### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/tsurei/manga/static/js/chapter-nav.js
+++ b/tsurei/manga/static/js/chapter-nav.js
@@ -3,7 +3,11 @@ document.addEventListener('DOMContentLoaded',function() {
 },false);
 
 function changeEventHandler(event) {
-    value = this.options[this.selectedIndex].value;
-    value = value.match(/\d+/g);
-    window.location.href = value[0];
+    let value = this.options[this.selectedIndex].value;
+    let match = value.match(/^\d+$/);
+    if (match) {
+        window.location.href = encodeURIComponent(match[0]);
+    } else {
+        console.error('Invalid value selected');
+    }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/dudujunior12/tsurei/security/code-scanning/1](https://github.com/dudujunior12/tsurei/security/code-scanning/1)

To fix the problem, we need to ensure that the value being used to set `window.location.href` is properly sanitized and validated. Since the value is expected to be numeric, we can use a more stringent validation method to ensure that only valid numeric values are used. Additionally, we can use `encodeURIComponent` to ensure that any special characters are properly escaped.

- Ensure that the value is a valid number before using it.
- Use `encodeURIComponent` to escape any special characters in the value.
- Update the `changeEventHandler` function to include these checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
